### PR TITLE
Setup a docs CI

### DIFF
--- a/.github/workflows/documenter.yml
+++ b/.github/workflows/documenter.yml
@@ -1,0 +1,57 @@
+name: Documenter
+on:
+  push:
+    branches: [master]
+    tags: [v*]
+  pull_request:
+
+jobs:
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    # Start with the default that it always runs
+    # if: contains( github.event.pull_request.labels.*.name, 'preview docs') || github.ref == 'refs/heads/master' || contains(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/checkout@v4
+      # as soon as we have tutorials with Quasrto the next lines are useful
+      #- uses: quarto-dev/quarto-actions/setup@v2
+      #  with:
+      #    version: "1.6.38"
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: "1.11"
+      - name: Julia Cache
+        uses: julia-actions/cache@v2
+      #- name: Cache Quarto
+      #  id: cache-quarto
+      #  uses: actions/cache@v4
+      #  env:
+      #    cache-name: cache-quarto
+      #  with:
+      #    path: tutorials/_freeze
+      #    key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('tutorials/*.qmd') }}
+      #    restore-keys: |
+      #      ${{ runner.os }}-${{ env.cache-name }}-
+      #- name: Cache Documenter
+      #  id: cache-documenter
+      #  uses: actions/cache@v4
+      #  env:
+      #    cache-name: cache-documenter
+      #  with:
+      #    path: docs/src/tutorials
+      #    key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('tutorials/*.qmd') }}
+      #    restore-keys: |
+      #      ${{ runner.os }}-${{ env.cache-name }}-
+      - name: "Documenter rendering (including Quarto)"
+        run: "docs/make.jl"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+  note:
+    name: "Documentation deployment note."
+    runs-on: ubuntu-latest
+    # see first note – we might move to docs rendering just on tag “preview docs”
+    #if: "!contains( github.event.pull_request.labels.*.name, 'preview docs')"
+    steps:
+      - name: echo instructions
+        run: echo 'The Documentation is only generated and pushed on a PR if the “preview docs” label is added.'

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,14 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
+DocumenterInterLinks = "d12716ef-a0f6-4df4-a9f1-a5a34e75c656"
 ManifoldDistributions = "8fe48565-f24b-4e2e-8b3e-841a9eec6bf2"
+
+[compat]
+Documenter = "1.11.1"
+DocumenterCitations = "1.4"
+DocumenterInterLinks = "0.3, 1"
+ManifoldDistributions = "0.1"
+
+[sources]
+ManifoldDistributions = {path = ".."}

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,14 +1,52 @@
+#!/usr/bin/env julia
+#
+#
+
+if "--help" ∈ ARGS
+    println(
+        """
+docs/make.jl
+
+Render the `ManifoldDistributions.jl` documentation with optional arguments
+
+Arguments
+* `--help`              - print this help and exit without rendering the documentation
+* `--prettyurls`        – toggle the pretty urls part to true, which is always set on CI
+"""
+    )
+    exit(0)
+end
+run_on_CI = (get(ENV, "CI", nothing) == "true")
+
+# On CI we activate this folders env anyways, but let's also do that here
+if Base.active_project() != joinpath(@__DIR__, "Project.toml")
+    using Pkg
+    Pkg.activate(@__DIR__)
+    Pkg.instantiate()
+end
+
+
 using ManifoldDistributions
-using Documenter
+using Documenter, DocumenterInterLinks, DocumenterCitations
 
 DocMeta.setdocmeta!(
     ManifoldDistributions, :DocTestSetup, :(using ManifoldDistributions); recursive=true
+)
+
+bib = CitationBibliography(joinpath(@__DIR__, "src", "references.bib"); style=:alpha)
+links = InterLinks(
+    "ManifoldsBase" => ("https://juliamanifolds.github.io/ManifoldsBase.jl/stable/"),
+    "Manifolds" => ("https://juliamanifolds.github.io/Manifolds.jl/stable/"),
 )
 
 makedocs(;
     modules=[ManifoldDistributions],
     authors="Seth Axen <seth@sethaxen.com> and contributors",
     sitename="ManifoldDistributions.jl",
-    format=Documenter.HTML(; edit_link="main", assets=String[]),
+    format=Documenter.HTML(;
+        edit_link="main", assets=String[], prettyurls=run_on_CI || ("--prettyurls" ∈ ARGS)
+    ),
     pages=["Home" => "index.md"],
+    plugins=[bib, links],
 )
+deploydocs(; repo="github.com/JuliaManifolds/ManifoldDistributions.jl", push_preview=true)


### PR DESCRIPTION
I was not so sure how to best help here.
I think the open issues and their details are great, but I do not have enough experience in distributions.

So here is what I think I can help with.

* setup a CI to render the docs
* extend the `make.jl` to
  * also run locally as a script
  * specify in the `docs/` environment that `ManifoldDistributions.jl` is always the one from the parent dir
  * add `DocoumenterCitations` so the can `[key](@cite)` literature from the `references.bib`
  * add `DocumenterInterLinks` so we can e.g. ``[`Rotations`](@extref)`` to the docs of other packages – for now I added `Manifolds.j` and `ManifoldsBase.jl`

I hope this is a nice small PR – and if I see further ideas I hope to be able to contribute more, since I like the idea of this package a lot.
